### PR TITLE
Refactor initialize

### DIFF
--- a/bundles/org.openhab.binding.mideaac/src/main/resources/OH-INF/i18n/mideaac.properties
+++ b/bundles/org.openhab.binding.mideaac/src/main/resources/OH-INF/i18n/mideaac.properties
@@ -104,11 +104,9 @@ channel-type.mideaac.turbo-mode.description = Turbo mode, "Boost" in Midea Air a
 
 # thing status descriptions
 
-offline.configuration_error_discovery = Required discovery parameter(s) are missing or invalid
 offline.configuration_pending_discovery = Retrieving required parameters via device discovery
 offline.communication_error_discovery = Could not retrieve required parameters via device discovery
 offline.configuration_error_invalid_discovery = Invalid discovery configuration parameters
-offline.configuration_error_token = Required cloud parameter(s) are missing or invalid
 offline.configuration_pending_token = Retrieving required parameters from the cloud provider
 offline.communication_error_token = Could not retrieve required parameters from the cloud
 offline.configuration_error_invalid_token = Invalid cloud configuration parameters provided


### PR DESCRIPTION
This PR does three changes:

1. Refactor the initialize method
    1. Extract logic to seperate methods
    2. Make use of early returns
4. Reduces the number of times the Thing Status is set
5. Fixes a minor i18n key issue.